### PR TITLE
update to embree 3.13.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "embree" %}
-{% set version = "2.17.7" %}
+{% set version = "3.13.2" %}
 
 package:
   name: {{ name }}
@@ -8,15 +8,15 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz  # [unix]
   url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x86_64.linux.tar.gz  # [linux64]
-  sha256: 2c4bdacd8f3c3480991b99e85b8f584975ac181373a75f3e9675bf7efae501fe  # [linux64]
+  sha256: 8142c1fa0e8e89e279581e873f558b008a3d49b9b1e0091393e50377bcc52639  # [linux64]
   url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x86_64.macosx.tar.gz  # [osx]
-  sha256: 48a2e81d6ccc8782c37f811afe2290969b288ee7264fdf5273eac349921c05df  # [osx]
+  sha256: 6e9442e516cd54c2e7f6454c90fb8cda5721d76a14d29880ffa387820a486762  # [osx]
   fn: {{ name }}-{{ version }}.zip  # [win]
-  url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x64.windows.zip  # [win]
-  sha256: 6fb7c828eef6cfe7186a5c002b52157a0d67471cf2c3072c3dced7d480071907  # [win]
+  url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x64.vc14.windows.zip  # [win]
+  sha256: 76570583a3d3e78f74b3cde2b0bbff8b0cc527959cc68b9e501b295e3aa7a960  # [win]
 
 build:
-  number: 1
+  number: 0
   detect_binary_files_with_prefix: true
   skip: true  # [aarch64 or ppc64le]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ *] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [*] Bumped the build number (if the version is unchanged)
* [*] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [*] Ensured the license file is being packaged.

This is a big upgrade and moves the package to the embree3 API. I'm alternatively happy to move this to either a new package or a branch in the same feedstock.

embree2 is not maintained any more and quite a few packages are now depending on embree 3 or want to depend on embree 3.
