### PR TITLE
Port embree3 feestock.

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -35,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,7 +4,15 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,9 +9,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 target_platform:
-- osx-64
+- osx-arm64
 tbb:
 - '2021'
 tbb_devel:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,5 +2,13 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2019
 target_platform:
 - win-64
+tbb:
+- '2021'
+tbb_devel:
+- '2021'
+vc:
+- '14'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joaander @Xarthisius @scopatz
+* @Xarthisius @joaander @scopatz

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -45,6 +45,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 
@@ -55,6 +54,10 @@ source run_conda_forge_build_setup
 
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 if [[ -f LICENSE.txt ]]; then

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-About embree
-============
+About embree3
+=============
 
 Home: https://embree.github.io/
 
-Package license: Apache 2.0
+Package license: Apache-2.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/embree-feedstock/blob/main/LICENSE.txt)
 
@@ -30,21 +30,28 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5193&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5193&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5193&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5193&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/embree-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>
@@ -60,53 +67,53 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-embree-green.svg)](https://anaconda.org/conda-forge/embree) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/embree.svg)](https://anaconda.org/conda-forge/embree) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/embree.svg)](https://anaconda.org/conda-forge/embree) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/embree.svg)](https://anaconda.org/conda-forge/embree) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-embree3-green.svg)](https://anaconda.org/conda-forge/embree3) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/embree3.svg)](https://anaconda.org/conda-forge/embree3) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/embree3.svg)](https://anaconda.org/conda-forge/embree3) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/embree3.svg)](https://anaconda.org/conda-forge/embree3) |
 
-Installing embree
-=================
+Installing embree3
+==================
 
-Installing `embree` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `embree3` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `embree` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `embree3` can be installed with `conda`:
 
 ```
-conda install embree
-```
-
-or with `mamba`:
-
-```
-mamba install embree
-```
-
-It is possible to list all of the versions of `embree` available on your platform with `conda`:
-
-```
-conda search embree --channel conda-forge
+conda install embree3
 ```
 
 or with `mamba`:
 
 ```
-mamba search embree --channel conda-forge
+mamba install embree3
+```
+
+It is possible to list all of the versions of `embree3` available on your platform with `conda`:
+
+```
+conda search embree3 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search embree3 --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search embree --channel conda-forge
+mamba repoquery search embree3 --channel conda-forge
 
-# List packages depending on `embree`:
-mamba repoquery whoneeds embree --channel conda-forge
+# List packages depending on `embree3`:
+mamba repoquery whoneeds embree3 --channel conda-forge
 
-# List dependencies of `embree`:
-mamba repoquery depends embree --channel conda-forge
+# List dependencies of `embree3`:
+mamba repoquery depends embree3 --channel conda-forge
 ```
 
 
@@ -151,17 +158,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating embree-feedstock
-=========================
+Updating embree3-feedstock
+==========================
 
-If you would like to improve the embree recipe or build a new
+If you would like to improve the embree3 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/embree-feedstock are
+Note that all branches in the conda-forge/embree3-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.
@@ -177,5 +184,6 @@ Feedstock Maintainers
 =====================
 
 * [@Xarthisius](https://github.com/Xarthisius/)
+* [@joaander](https://github.com/joaander/)
 * [@scopatz](https://github.com/scopatz/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,12 @@
-provider: {linux_aarch64: default, linux_ppc64le: default}
+build_platform: {osx_arm64: osx_64}
+provider: {win: azure}
+test_on_native_only: true
 conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+bot:
+  abi_migration_branches:
+    - v2

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,33 @@
-robocopy . %LIBRARY_PREFIX% /MIR
-IF %ERRORLEVEL% LSS 8 goto finish
+setlocal EnableDelayedExpansion
 
-Echo Install failed & goto :eof
+:: Make build directory
+mkdir build
+cd build
 
-:finish
-Echo All done, no fatal errors.
+:: Specify location of TBB
+set "TBBROOT=%LIBRARY_PREFIX%"
+
+:: Configure
+cmake ../ ^
+      -G "NMake Makefiles" ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_LIBDIR=lib ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DEMBREE_TUTORIALS=OFF ^
+      -DEMBREE_MAX_ISA="AVX2" ^
+      -DEMBREE_ISPC_SUPPORT=OFF
+if errorlevel 1 exit 1
+
+:: Compile
+nmake
+if errorlevel 1 exit 1
+
+:: embree lacks unit tests
+
+nmake install
+if errorlevel 1 exit 1
+
+:: remove tutorial models (which embree installed even when EMBREE_TUTORIALS=off)
+:: this is easier than patching embree's cmake
+rd /s /q %LIBRARY_PREFIX%/bin/models
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,33 @@
-#!/bin/bash
-set -e
-cd lib
-if [ ! -f "libembree${SHLIB_EXT}" ]
-then
-  ln -s libembree.so libembree${SHLIB_EXT}
+# Make build directory
+mkdir build
+cd build
+
+# Specify location of TBB
+export TBBROOT=${PREFIX}
+
+if [ "${target_platform}" == "osx-arm64" ]; then
+    max_isa="NEON"
+else
+    max_isa="AVX2"
 fi
-cd ..
-cp -rv * "${PREFIX}"
+
+# Configure
+cmake ${CMAKE_ARGS} ../ \
+      -DEMBREE_IGNORE_CMAKE_CXX_FLAGS=OFF \
+      -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DEMBREE_TUTORIALS=OFF \
+      -DEMBREE_MAX_ISA="${max_isa}" \
+      -DEMBREE_ISPC_SUPPORT=OFF
+
+# Compile
+make -j ${CPU_COUNT}
+
+# embree lacks unit tests
+
+make install
+
+# remove tutorial models (which embree installed even when EMBREE_TUTORIALS=off)
+# this is easier than patching embree's cmake
+rm -rf ${PREFIX}/bin/models

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
+    - make  # [unix]
 
   host:
     - tbb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,43 @@
-{% set name = "embree" %}
-{% set version = "2.17.7" %}
+{% set name = "embree3" %}
+{% set version = "3.13.0" %}
+{% set sha256 = "4d86a69508a7e2eb8710d571096ad024b5174834b84454a8020d3a910af46f4f" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz  # [unix]
-  url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x86_64.linux.tar.gz  # [linux64]
-  sha256: 2c4bdacd8f3c3480991b99e85b8f584975ac181373a75f3e9675bf7efae501fe  # [linux64]
-  url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x86_64.macosx.tar.gz  # [osx]
-  sha256: 48a2e81d6ccc8782c37f811afe2290969b288ee7264fdf5273eac349921c05df  # [osx]
-  fn: {{ name }}-{{ version }}.zip  # [win]
-  url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.x64.windows.zip  # [win]
-  sha256: 6fb7c828eef6cfe7186a5c002b52157a0d67471cf2c3072c3dced7d480071907  # [win]
+  fn: {{ version }}.tar.gz
+  url: https://github.com/embree/embree/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - use-conda-forge-ABI.patch
 
 build:
-  number: 3
-  detect_binary_files_with_prefix: true
-  skip: true  # [aarch64 or ppc64le]
+  number: 0
+  # upstream supports visual studio 13+
+  skip: true  # [win and vc<13]]
 
 requirements:
   build:
-    - python  # [win]
+    - {{ compiler('cxx') }}
+    - cmake
+
+  host:
+    - tbb
+    - tbb-devel
+
+  run:
+    - tbb
 
 test:
   commands:
-    - test -f "${PREFIX}/lib/libembree.so"  # [linux]
-    - test -f "${PREFIX}/lib/libembree.dylib"  # [osx]
+    - test -f "${PREFIX}/lib/libembree3${SHLIB_EXT}"  # [not win]
 
 about:
   home: https://embree.github.io/
-  license: Apache 2.0
-  license_file: doc/LICENSE.txt
+  license: Apache-2.0
+  license_file: LICENSE.txt
   summary: High Performance Ray Tracing Kernels
 
 extra:

--- a/recipe/use-conda-forge-ABI.patch
+++ b/recipe/use-conda-forge-ABI.patch
@@ -1,0 +1,12 @@
+diff --git a/common/cmake/gnu.cmake b/common/cmake/gnu.cmake
+index 72c364267..407d889eb 100644
+--- a/common/cmake/gnu.cmake
++++ b/common/cmake/gnu.cmake
+@@ -40,7 +40,6 @@ IF (NOT APPLE)
+ ENDIF()
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")                       # generate position independent code suitable for shared libraries
+ SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC")                       # generate position independent code suitable for shared libraries
+-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")                  # enables C++11 features
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")         # makes all symbols hidden by default
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden") # makes all inline symbols hidden by default
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")        # disables strict aliasing rules


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Per discussions with @beckermr on gitter who suggested merging `embree3` with `embree` and adding abi migration branches:
* I created the `v2` branch.
* This pull request ports recipe from the embree 3.x feestock I have maintained: https://github.com/conda-forge/embree3-feedstock. This builds the latest embree 3.x release for linux-64, osx-64, osx-arm64 (new) and win-64.

I have not used abi migration branches before. Is this correct?

Sometime after this pull request I plan to create the `v3` branch and make another pull request to update `main` to embree v4.0.0.