### PR TITLE
Enable ISPC support

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Xarthisius @joaander @scopatz
+* @Xarthisius @eunos-1128 @joaander @scopatz

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,11 +23,13 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -104,7 +106,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Feedstock Maintainers
 =====================
 
 * [@Xarthisius](https://github.com/Xarthisius/)
+* [@eunos-1128](https://github.com/eunos-1128/)
 * [@joaander](https://github.com/joaander/)
 * [@scopatz](https://github.com/scopatz/)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,7 +15,7 @@ cmake ../ ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DEMBREE_TUTORIALS=OFF ^
       -DEMBREE_MAX_ISA="AVX2" ^
-      -DEMBREE_ISPC_SUPPORT=OFF
+      -DEMBREE_ISPC_SUPPORT=ON
 if errorlevel 1 exit 1
 
 :: Compile

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ cmake ${CMAKE_ARGS} ../ \
       -DCMAKE_BUILD_TYPE=Release \
       -DEMBREE_TUTORIALS=OFF \
       -DEMBREE_MAX_ISA="${max_isa}" \
-      -DEMBREE_ISPC_SUPPORT=OFF
+      -DEMBREE_ISPC_SUPPORT=ON
 
 # Compile
 make -j ${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - use-conda-forge-ABI.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('embree', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,3 +45,4 @@ extra:
     - joaander
     - scopatz
     - Xarthisius
+    - eunos-1128

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - {{ stdlib("c") }}
     - cmake
     - make  # [unix]
+    - ispc
 
   host:
     - tbb


### PR DESCRIPTION
OSPRay (and likely openvkl) requires `EMBREE_ISPC_SUPPORT=ON`.
Currently embree is built with ISPC support OFF, causing OSPRay's cmake configure to fail for [conda-packaging OSPRay](https://github.com/conda-forge/staged-recipes/pull/33242#issuecomment-4393901490).

This PR adds `ispc` to build deps and enables `-DEMBREE_ISPC_SUPPORT=ON`.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
