### PR TITLE
Change `max_isa` for osx-64, linux-aarch64 and win-arm64

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,7 +14,5 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-64
-tbb:
-- '2022'
 tbb_devel:
 - '2022'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -14,7 +14,5 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-aarch64
-tbb:
-- '2022'
 tbb_devel:
 - '2022'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,7 +18,5 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
-tbb:
-- '2022'
 tbb_devel:
 - '2022'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,7 +18,5 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
-tbb:
-- '2022'
 tbb_devel:
 - '2022'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,7 +8,5 @@ cxx_compiler:
 - vs2022
 target_platform:
 - win-64
-tbb:
-- '2022'
 tbb_devel:
 - '2022'

--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@ About embree-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/embree-feedstock/blob/main/LICENSE.txt)
 
-Home: https://embree.github.io/
+Home: https://www.embree.org/
 
 Package license: Apache-2.0
 
 Summary: High Performance Ray Tracing Kernels
+
+Development: https://github.com/RenderKit/embree
+
+Documentation: https://github.com/RenderKit/embree/blob/v4.4.1/readme.pdf
+
+Intel® Embree is a high-performance ray tracing library developed at Intel, which is released as open source under the Apache 2.0 license.
+Intel® Embree supports x86 CPUs under Linux, macOS, and Windows; ARM CPUs on Linux and macOS; as well as Intel® GPUs under Linux and Windows.
+
+Intel® Embree targets graphics application developers to improve the performance of photo-realistic rendering applications.
+Embree is optimized towards production rendering, by putting focus on incoherent ray performance, high quality acceleration structure construction, a rich feature set, accurate primitive intersection, and low memory consumption.
 
 Current build status
 ====================

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -7,7 +7,7 @@ set "TBBROOT=%LIBRARY_PREFIX%"
 if "%target_platform%"=="win-64" (
     set "max_isa=AVX512"
 ) else if "%target_platform%"=="win-arm64" (
-    set "max_isa=NEON"
+    set "max_isa=NEON2X"
 )
 
 :: Configure

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ if [[ "${target_platform}" == *"linux-64" ]] ; then
 elif [[ "${target_platform}" == "osx-64" ]]; then
     max_isa="AVX2"
 elif [[ "${target_platform}" == "linux-aarch64" ]]; then
-    max_isa="NEON"
+    max_isa="NEON2X"
 elif [[ "${target_platform}" == "osx-arm64" ]]; then
     max_isa="NEON2X"
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,8 +4,10 @@ set -exo pipefail
 # Specify location of TBB
 export TBBROOT=${PREFIX}
 
-if [[ "${target_platform}" == *"-64" ]] ; then
+if [[ "${target_platform}" == *"linux-64" ]] ; then
     max_isa="AVX512"
+elif [[ "${target_platform}" == "osx-64" ]]; then
+    max_isa="AVX2"
 elif [[ "${target_platform}" == "linux-aarch64" ]]; then
     max_isa="NEON"
 elif [[ "${target_platform}" == "osx-arm64" ]]; then

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - use-conda-forge-ABI.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Fix `max_isa` for three platforms:

- **osx-64**: macOS does not enable AVX512 in XCR0 by default, so Embree's runtime ISA detection does not select AVX512 kernels.
- **linux-aarch64 / win-arm64**: NEON → NEON2X. NEON2X uses pairs of 128-bit NEON registers to emulate 256-bit width, enabling 8-wide BVH traversal and ray packet kernels. This is supported on all AArch64 hardware and matches what downstream consumers like OSPRay, Open VKL, etc. expect for optimal performance. No compatibility regression.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
